### PR TITLE
Make Google forms more responsive

### DIFF
--- a/content/code-conduct.ca.md
+++ b/content/code-conduct.ca.md
@@ -69,4 +69,4 @@ organitzadors poden prendre la decisió d'actuar de manera que ells creguin que 
 incloent-hi avisar o expulsar l’assetjador de l'esdeveniment sense dret al reemborsament o del
 bloqueig del seu compte quan es tracta d'una participació online.
 
-{{< google-form src="https://docs.google.com/forms/d/e/1FAIpQLSdR9fC-OdIlOjnBBpWbd7hRN3kXbtVtTvEWUzWYdxOoJ8NGPA/viewform?embedded=true" width="800" height="1600" >}}
+{{< google-form src="https://docs.google.com/forms/d/e/1FAIpQLSdR9fC-OdIlOjnBBpWbd7hRN3kXbtVtTvEWUzWYdxOoJ8NGPA/viewform?embedded=true" width="95%" height="1600px" >}}

--- a/content/code-conduct.en.md
+++ b/content/code-conduct.en.md
@@ -45,4 +45,4 @@ Participants asked to stop any harassing behavior are expected to comply immedia
 
 This policy extends to talks, forums, workshops, codelabs, social media, all attendees, partners, sponsors, volunteers, organizers, speakers, staff, etc. You catch our drift. We reserve the right to refuse admittance to, or remove any person from, any of the events that we organize at any time in its sole discretion. This includes, but is not limited to, attendees behaving in a disorderly manner or failing to comply with this policy, and the terms and conditions herein. If a participant engages in harassing or uncomfortable behavior, the organizers may take any action they deem appropriate, including warning or expelling the offender from the event with no refund or blocking the offender’s account from participating online.
 
-{{< google-form src="https://docs.google.com/forms/d/e/1FAIpQLScTyVZdOuQB2m9YYIpoV6DfloIkBg-Iibe8rGeTFGwdoix_Gg/viewform?embedded=true" width="800" height="1600" >}}
+{{< google-form src="https://docs.google.com/forms/d/e/1FAIpQLScTyVZdOuQB2m9YYIpoV6DfloIkBg-Iibe8rGeTFGwdoix_Gg/viewform?embedded=true" width="95%" height="1600px" >}}

--- a/content/sign-up-member.ca.md
+++ b/content/sign-up-member.ca.md
@@ -11,4 +11,4 @@ comunitat sense cap obligació par ambdues parts.
 
 Només contactarem amb tu quan programem nou esdeveniments i activitats.
 
-{{< google-form src="https://docs.google.com/forms/d/e/1FAIpQLSdiJ3dQmL-Ei_ufi86a2PYUyCjCjear6w0Ry1i3zSlwvgFXNw/viewform?embedded=true" width="800" height="1500" >}}
+{{< google-form src="https://docs.google.com/forms/d/e/1FAIpQLSdiJ3dQmL-Ei_ufi86a2PYUyCjCjear6w0Ry1i3zSlwvgFXNw/viewform?embedded=true" width="95%" height="1470px" >}}

--- a/content/sign-up-member.en.md
+++ b/content/sign-up-member.en.md
@@ -11,4 +11,4 @@ Signing up is __free__ and manifest your legitimate interest in whit community w
 
 We only contact you when we schedule a new events and activities.
 
-{{< google-form src="https://docs.google.com/forms/d/e/1FAIpQLSf5C6ndJFtFD_7Y-0KPtcn21ID-OwJ4WXt6-brBOkndKFSO7A/viewform?embedded=true" width="800" height="1500" >}}
+{{< google-form src="https://docs.google.com/forms/d/e/1FAIpQLSf5C6ndJFtFD_7Y-0KPtcn21ID-OwJ4WXt6-brBOkndKFSO7A/viewform?embedded=true" width="95%" height="1470px" >}}

--- a/content/talk-proposal.ca.md
+++ b/content/talk-proposal.ca.md
@@ -11,4 +11,4 @@ esdeveniments [aquí]({{< ref "organization-events" >}}).
 
 Moltes gràcies per la teva proposta.
 
-{{< google-form src="https://docs.google.com/forms/d/e/1FAIpQLSdChb6MCxFlA4lHf2vG1j6Zmf_X3xmzjAtK6MofadrvW0usfw/viewform?embedded=true" width="800" height="1800" >}}
+{{< google-form src="https://docs.google.com/forms/d/e/1FAIpQLSdChb6MCxFlA4lHf2vG1j6Zmf_X3xmzjAtK6MofadrvW0usfw/viewform?embedded=true" width="95%" height="1820px" >}}

--- a/content/talk-proposal.en.md
+++ b/content/talk-proposal.en.md
@@ -10,4 +10,4 @@ You can know more about how we organize our events [here]({{< ref "organization-
 
 Thank you very much for your proposal.
 
-{{< google-form src="https://docs.google.com/forms/d/e/1FAIpQLSdDPyzOy9L_943hp21LP6IFnH6Wd29q-fm5m1M2egbCIZEt5A/viewform?embedded=true" width="800" height="1800" >}}
+{{< google-form src="https://docs.google.com/forms/d/e/1FAIpQLSdDPyzOy9L_943hp21LP6IFnH6Wd29q-fm5m1M2egbCIZEt5A/viewform?embedded=true" width="95%" height="1800px" >}}

--- a/layouts/shortcodes/google-form.html
+++ b/layouts/shortcodes/google-form.html
@@ -1,3 +1,1 @@
-<div style="text-align: center">
-  <iframe src="{{ .Get "src" }}" width="{{ .Get "width" }}" height="{{ .Get "height" }}" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
-</div>
+<iframe src="{{ .Get "src" }}" style="width:{{ .Get "width" }}; height:{{ .Get "height" }}" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>


### PR DESCRIPTION
Adjust the Google form short code to be more responsive friendly and update the width and height arguments on the pages that use it.

This make the forms not to overflow horizontally on small screens and the height works without showing a scroll in the iframe for big screens, while in smaller screens the scroll show up for avoiding a vertical overflow.