### PR TITLE
site: Add language selector top bar

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,17 +1,17 @@
 <!DOCTYPE HTML>
 <!--
-	Spectral by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+  Spectral by HTML5 UP
+  html5up.net | @ajlkn
+  Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
 <html lang="{{ .Site.Language.Lang | default "en-us" }}">
-	<head>
-	  <title>{{ .Title }}</title>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="referrer" content="origin">
+  <head>
+    <title>{{ .Title }}</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="referrer" content="origin">
 
-	{{ template "_internal/google_analytics.html" . }}
+  {{ template "_internal/google_analytics.html" . }}
 
     {{ with .Site.Params.description }}<meta name="description" content="{{ . | plainify }}">{{ end }}
     {{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
@@ -27,24 +27,27 @@
     {{ template "_internal/twitter_cards.html" . }}
     {{ template "_internal/opengraph.html" . }}
     {{ partial "hooks/head-end.html" . }}
-	</head>
-	<body class="landing is-preload">
+  </head>
+  <body class="landing is-preload">
 
-		<!-- Page Wrapper -->
-			<div id="page-wrapper">
+    <!-- Page Wrapper -->
+      <div id="page-wrapper">
 
-				<!-- Header -->
+        <!-- Header -->
           <header id="header"{{ if .Page.IsHome }} class="alt"{{ end }}>
             <h1><a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a></h1>
-						{{- with index site.Menus "main" }}
-						<nav id="nav">
-							<ul>
-								<li class="special">
+            {{- with index site.Menus "main" }}
+            <nav id="nav">
+              <ul>
+                {{ range $.Translations }}
+                <li><a href="{{ .RelPermalink }}">{{ .Lang }}</a><li/>
+                {{ end }}
+                <li class="special">
                   <a href="#menu" class="menuToggle" aria-label='{{ i18n "menu" }}'><span>{{ i18n "menu" }}</span></a>
-									<div id="menu">
-										<ul>
- 											{{- range . }}
-											<li><a href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+                  <div id="menu">
+                    <ul>
+                       {{- range . }}
+                      <li><a href="{{ .URL | relURL }}">{{ .Name }}</a></li>
                         {{ if .HasChildren }}
                         <ul>
                           {{- range .Children }}
@@ -52,11 +55,11 @@
                           {{ end -}}
                         </ul>
                         {{ end -}}
- 											{{ end -}}
-										</ul>
-									</div>
-								</li>
-							</ul>
-						</nav>
+                       {{ end -}}
+                    </ul>
+                  </div>
+                </li>
+              </ul>
+            </nav>
             {{- end }}
-					</header>
+          </header>


### PR DESCRIPTION
Add the list of available page's languages into the top site bar to allow the user to manually select it.

The commit also homogenize the partial to use spaces and not a mix of tab and space for indentation.