### PR TITLE
site: Add discord link

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -25,6 +25,7 @@ body_is_markdown = true
 [params.social]
 github = 'siliconguilleries'
 twitter = 'siguilleries'
+discord = 'gsjVvHnXYd'
 # instagram = ''
 # youtube = ''
 # mastodon = ''


### PR DESCRIPTION
Add the link to Silicon Guilleries discord server.

This required to update the theme because Discord was not an option in the previous theme version.