### PR TITLE
theme: Update spectral repo & pull last updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "themes/spectral"]
 	path = themes/spectral
-	url = git@github.com:ifraixedes/sbruder-spectral.git
-	branch = if/all-my-non-merged-prs
+	url = git@github.com:siliconguilleries/sbruder-spectral.git
+	branch = silicon-guilleries

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -24,7 +24,7 @@ body_is_markdown = true
 
 [params.social]
 github = 'siliconguilleries'
-twitter = 'siguilleries'
+x = 'siguilleries'
 discord = 'gsjVvHnXYd'
 # instagram = ''
 # youtube = ''


### PR DESCRIPTION
Change the spectral repository to the new Github repository after I moved from my user to the siliconguilleries Github organization.

The new repository uses 'silicon-guilleries' as the default branch because it contains updates that are used by the Silicon Guilleries website and because those changes aren't merged into the origin repository that it was forked.

Some of the changes were pushed as pull requests into the origin repository but, after several weeks of not having any response, I don't expect that there will be any intention by the owner of reviewing them to consider if merging. Because of that unresponsiveness, I added other new commits that I didn't send as pull requests and I don't plan to send them.

The last theme's updates has moved Twitter to X, so I updated the configuration of this site to reference X and continue showing the link to this social network.