### PR TITLE
Publish second meetup 

### DIFF
--- a/config/_default/language.ca.toml
+++ b/config/_default/language.ca.toml
@@ -6,7 +6,7 @@ weight = 1
 
 [params]
 fancyTitle = 'Silicon Guilleries'
-description = 'La comunitat tècnica de les Guilleries'
+description = 'La comunitat tècnica de les Guilleries<br/>> <a href="events-next" style="font-weight: bold">Pròxima troba</a> <'
 
 [params.one]
 enable = true

--- a/config/_default/language.en.toml
+++ b/config/_default/language.en.toml
@@ -6,7 +6,7 @@ weight = 10
 
 [params]
 fancyTitle = 'Silicon Guilleries'
-description = 'The Guilleries tech comunity'
+description = 'The Guilleries tech comunity<br/>> <a href="events-next" style="font-weight: bold">Next meetup</a> <'
 
 [params.one]
 enable = true

--- a/content/events-next/disabled.index.ca.md
+++ b/content/events-next/disabled.index.ca.md
@@ -3,6 +3,7 @@ author = 'Ivan Fraixedes'
 title = 'Próxims esdeviments'
 description = "No tenim próxims esdeveniments programats, els estem organitzant"
 date = 2024-03-14T16:00:00+01:00
+draft = true
 +++
 
 No tenim próxims esdeveniments programats, però continuat visitant-nos per estar al corrent dels que estem organitzant.

--- a/content/events-next/disabled.index.en.md
+++ b/content/events-next/disabled.index.en.md
@@ -3,6 +3,7 @@ author = 'Ivan Fraixedes'
 title = 'Next events'
 description = "We don't have any scheduled events, we are organizing them"
 date = 2024-03-14T16:00:00+01:00
+draft = true
 +++
 
 We don't have any scheduled event, but stay tuned because we are organizing them.

--- a/content/events-next/topics-of-interest.ca.md
+++ b/content/events-next/topics-of-interest.ca.md
@@ -1,0 +1,29 @@
++++
+author = 'Ivan Fraixedes'
+title = "Temes d'interés"
+description ="Segona troba presencial on farem una llista de temes que poden ser d'interès pels membre de la nostra petita comunitat"
+date = 2024-04-29T10:00:00+02:00
+category = 'events'
+
+[params]
+[params.event]
+when = 2024-05-15T19:00:00+02:00
+where = 'Casa de Cultura (Sant Hilari Sacalm)'
++++
+
+Després de la nostra primera trobada on ens vam conèixer tots els que vam expressar un interès en la nostra comunitat, ens tornem a trobar novament per fer una llista de temes que són interessants pels assistents.
+<!--more-->
+
+Uneix-te a nosaltres per a la nostra segona trobada mentre ens reunim una altra vegada per donar forma a les futures discussions de la nostra creixent comunitat tecnològica. Aprofitant l'èxit de la nostra primera trobada on vam connectar amb gairebé tothom interessat en la nostra comunitat, estem emocionats per explorar més a fons els temes que desperten el vostre interès.
+
+Tenim com a objectiu recopilar una llista de temes que ressonin amb cada assistent, ja sigui alguna cosa que desitgeu compartir la vostra experiència o un tema que vulgueu explorar més a fons amb altres entusiastes. Ja siguis un professional experimentat que vulgui compartir el seu coneixement en futures trobades o simplement un interessat en absorbir coneixements dels altres, sou benvinguts a unir-vos a nosaltres sense cap compromís.
+
+No estàs segur de quins temes suggerir? Cap problema! Només amb la teva presència ja aporta valor a les nostres discussions. Passa i digues hola i comparteix els teus pensaments o suggeriments. Tenim l'objectiu de fomentar un ambient inclusiu on cada veu té importància.
+
+Esperem veure-us allà!
+
+## Registre
+
+:warning: Si us plau abans de registrar-te a l'esdeviniment, [registrat com a membre](/sign-up-member).
+
+{{< google-form src="https://docs.google.com/forms/d/e/1FAIpQLScxPm1berinkzmbTdmZBUW19eU-rf35mvcCL8dxf_wsjUbb2g/viewform?embedded=true" width="95%" height="600px" >}}

--- a/content/events-next/topics-of-interest.en.md
+++ b/content/events-next/topics-of-interest.en.md
@@ -1,0 +1,29 @@
++++
+author = 'Ivan Fraixedes'
+title = 'Topics of interest'
+description = 'Second in-person meetup to list the topics that every member of our small community is interested in'
+date = 2024-04-29T10:00:00+02:00
+category = 'events'
+
+[params]
+[params.event]
+when = 2024-05-15T19:00:00+02:00
+where = 'Casa de Cultura (Sant Hilari Sacalm)'
++++
+
+After our first meetup where we met almost everybody who expressed interest in our community, we are going to meet again to compose a list of topics that every attendee is interested.
+<!--more-->
+
+Join us for our second meetup as we gather once again to shape the future discussions of our growing tech community. Building upon the success of our inaugural gathering where we connected with nearly everyone interested in our community, we're excited to delve deeper into the topics that pique your interest.
+
+We aim to compile a list of subjects that resonate with each attendee, whether it's something you're eager to share your expertise on or a topic you're keen to explore further with fellow enthusiasts. Whether you're a seasoned professional looking to impart knowledge in future meetups or simply interested in absorbing insights from others, you're welcome to join us – there's no pressure to commit.
+
+Not sure what topics to suggest? No problem! Your presence alone adds value to our discussions. Feel free to drop by, say hi, and share your thoughts or suggestions. We're all about fostering an inclusive environment where every voice matters.
+
+Looking forward to seeing you there!
+
+## Sign up
+
+:warning: Please before sign up to the event, [sign up as a member](/sign-up-member).
+
+{{< google-form src="https://docs.google.com/forms/d/e/1FAIpQLSfwuEGTCMEVdB5JezCiqA8zArfKt8NXKYeIrqWlUHHKKSVsIw/viewform?embedded=true" width="95%" height="600px" >}}


### PR DESCRIPTION
The main goal of the PR is to publish the second meetup.

It has other changes that aren't just for publishing the meetup, however, they are related in how to manage the next events section and how to make them visible from the home page.