### PR TITLE
content: Move last event to past section

### DIFF
--- a/config/_default/language.ca.toml
+++ b/config/_default/language.ca.toml
@@ -6,7 +6,7 @@ weight = 1
 
 [params]
 fancyTitle = 'Silicon Guilleries'
-description = 'La comunitat tècnica de les Guilleries<br/>> <a href="events-next" style="font-weight: bold">Pròxima troba</a> <'
+description = 'La comunitat tècnica de les Guilleries'
 
 [params.one]
 enable = true

--- a/config/_default/language.en.toml
+++ b/config/_default/language.en.toml
@@ -6,7 +6,7 @@ weight = 10
 
 [params]
 fancyTitle = 'Silicon Guilleries'
-description = 'The Guilleries tech comunity<br/>> <a href="events-next" style="font-weight: bold">Next meetup</a> <'
+description = 'The Guilleries tech comunity'
 
 [params.one]
 enable = true

--- a/content/events-next/index.ca.md
+++ b/content/events-next/index.ca.md
@@ -3,7 +3,6 @@ author = 'Ivan Fraixedes'
 title = 'Próxims esdeviments'
 description = "No tenim próxims esdeveniments programats, els estem organitzant"
 date = 2024-03-14T16:00:00+01:00
-draft = true
 +++
 
 No tenim próxims esdeveniments programats, però continuat visitant-nos per estar al corrent dels que estem organitzant.

--- a/content/events-next/index.en.md
+++ b/content/events-next/index.en.md
@@ -3,7 +3,6 @@ author = 'Ivan Fraixedes'
 title = 'Next events'
 description = "We don't have any scheduled events, we are organizing them"
 date = 2024-03-14T16:00:00+01:00
-draft = true
 +++
 
 We don't have any scheduled event, but stay tuned because we are organizing them.

--- a/content/events-past/topics-of-interest.ca.md
+++ b/content/events-past/topics-of-interest.ca.md
@@ -4,6 +4,8 @@ title = "Temes d'interés"
 description ="Segona troba presencial on farem una llista de temes que poden ser d'interès pels membre de la nostra petita comunitat"
 date = 2024-04-29T10:00:00+02:00
 category = 'events'
+aliases = ['/events-next/topics-of-interest']
+
 
 [params]
 [params.event]

--- a/content/events-past/topics-of-interest.en.md
+++ b/content/events-past/topics-of-interest.en.md
@@ -4,6 +4,7 @@ title = 'Topics of interest'
 description = 'Second in-person meetup to list the topics that every member of our small community is interested in'
 date = 2024-04-29T10:00:00+02:00
 category = 'events'
+aliases = ['/en/events-next/topics-of-interest']
 
 [params]
 [params.event]


### PR DESCRIPTION
The event happened yesterday, this commit moves it to the past events section, remove the link from the home page, and enable back the index pages in the next events to show that there isn't any planed upcoming event at this moment.